### PR TITLE
Add lightweight health check flag for local CLI

### DIFF
--- a/app/local_cli.py
+++ b/app/local_cli.py
@@ -7,12 +7,22 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from collections import deque
-from wba.local_rag import LocalRAG
+import argparse
 
 DEBUG_MODE  = bool(os.getenv("WBA_DEBUG"))
 MEM_HISTORY = deque(maxlen=6)     # (question, answer) pairs
 
 def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--health", action="store_true", help="Run a basic health check and exit")
+    args = parser.parse_args()
+
+    if args.health:
+        print("OK")
+        return
+
+    from wba.local_rag import LocalRAG
+
     rag     = LocalRAG(json_path="extracted_text.json")
     history = []      # last full turns for rag.answer()
     topic   = None    # sticky entity


### PR DESCRIPTION
## Summary
- add `--health` CLI flag that prints `OK` and exits
- import model code only when needed so health check avoids heavy model loading

## Testing
- `PYTHONPATH=src python app/local_cli.py --health`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'document_store'; openai.lib._old_api.APIRemovedInV1)*

------
https://chatgpt.com/codex/tasks/task_e_689f3c023fd8832fa9a2cf35de6ce982