### PR TITLE
Fix mistral topic detection and add regression test

### DIFF
--- a/src/wba/local_rag.py
+++ b/src/wba/local_rag.py
@@ -313,19 +313,28 @@ class LocalRAG:
         q_low = question.lower()
         include, exclude = [], []
 
-        # Entity bias for stickiness
-        if sticky_topic == "windeward" or "windeward" in q_low:
+        # Prefer entities mentioned in the current question; fall back to the
+        # previous sticky topic only if no entity is mentioned.
+        if "windeward" in q_low:
             include.append("windeward")
             exclude.extend(["mistral", "blue water warriors"])
-        elif sticky_topic == "mistral" or "mistral" in q_low:
+        elif "mistral" in q_low:
             include.append("mistral")
+        elif sticky_topic == "windeward":
+            include.append("windeward")
+            exclude.extend(["mistral", "blue water warriors"])
+        elif sticky_topic == "mistral":
+            include.append("mistral")
+
         include = include or None
         exclude = exclude or None
 
         top = self.retrieve(question, top_k=top_k, include=include, exclude=exclude)
         if not top:
-            return ("Can’t say for certain from the ship’s logs—no relevant texts aboard.",
-                    {"pages": [], "context": [], "topic": sticky_topic})
+            return (
+                "Can’t say for certain from the ship’s logs—no relevant texts aboard.",
+                {"pages": [], "context": [], "topic": sticky_topic},
+            )
 
         fed_sents, pages = _concat_with_pages(question, top, char_budget=1500)
 

--- a/tests/topic_switch_test.py
+++ b/tests/topic_switch_test.py
@@ -1,0 +1,55 @@
+import pytest
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+from wba.local_rag import LocalRAG
+
+
+def make_rag():
+    # Construct a LocalRAG without invoking __init__ to avoid heavy embedding work
+    rag = LocalRAG.__new__(LocalRAG)
+    rag.pages = [
+        {
+            "content": "The Windeward Bound is a tall ship from Hobart offering sail training voyages around Tasmania for young crew.",
+            "page_num": 1,
+        },
+        {
+            "content": "The Mistral II is a new training vessel being built to expand youth sail training opportunities across Australia.",
+            "page_num": 2,
+        },
+    ]
+    return rag
+
+
+def fake_retrieve(self, query, top_k=8, include=None, exclude=None):
+    results = []
+    for p in self.pages:
+        text = p["content"].lower()
+        if include and not all(term in text for term in include):
+            continue
+        if exclude and any(term in text for term in exclude):
+            continue
+        results.append(p)
+    return results
+
+
+def fake_gen_chat(messages, max_new_tokens=180):
+    # Echo the context to make assertions easy
+    user = messages[-1]["content"]
+    ctx = user.split("CONTEXT:\n", 1)[1].split("\n\nQUESTION:", 1)[0]
+    return ctx.strip()
+
+
+def test_topic_switch_mistral_overrides_windeward(monkeypatch):
+    rag = make_rag()
+    monkeypatch.setattr(LocalRAG, "retrieve", fake_retrieve)
+    import wba.local_rag as lr
+    monkeypatch.setattr(lr, "_gen_chat", fake_gen_chat)
+
+    ans1, info1 = rag.answer("Tell me about the Windeward Bound.")
+    assert "Windeward Bound" in ans1
+    assert info1["topic"] == "windeward"
+
+    ans2, info2 = rag.answer("And what is Mistral II?", sticky_topic=info1["topic"])
+    assert "Mistral II" in ans2
+    assert "Windeward" not in ans2
+    assert info2["topic"] == "mistral"


### PR DESCRIPTION
## Summary
- Prioritize explicit mentions of Windeward or Mistral when retrieving documents and determining sticky topics
- Clean up LocalRAG.answer and remove stray terminal output
- Add regression test ensuring Mistral questions override Windeward context

## Testing
- `pytest tests/topic_switch_test.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'document_store'; openai API removed)*

------
https://chatgpt.com/codex/tasks/task_e_689f3bfc1184832f97a31f7ed96af1de